### PR TITLE
日本語版職務経歴書を追加しリンクを更新

### DIFF
--- a/docs/職務経歴書_渡邉泰曉.md
+++ b/docs/職務経歴書_渡邉泰曉.md
@@ -6,7 +6,6 @@
 ## 職務要約
 
 バックエンドエンジニア。6年の実務経験。Go、TypeScript、PHPを中心にWebアプリケーションの設計・開発・運用に従事。直近では認証基盤のマイクロサービス化をテックリードとして推進し、テスト自動化・CI/CD整備による品質改善およびチーム生産性の向上に取り組む。
-認証・データ基盤など、プロダクトを横断して支えるプラットフォーム領域に関心を持つ。
 
 ## 職務経歴
 
@@ -14,23 +13,26 @@
 
 #### シニアソフトウェアエンジニア（2025年3月〜現在）
 
-- 3万MAUのGo Next.jsによるスポットバイトルの開発（2025年9月〜現在）
+- **スポットワーク認証基盤のマイクロサービス化（2026年2月〜現在）**
+  - 別チームが構築したCognito認証基盤へのスポットバイトル管理画面からのつなぎ込みを担当。認証基盤チームへ設計を認可コードフロー実装の提案・壁打ちし認証方式の検討を主導。セキュリティ・スケーラビリティを考慮した認可コードフローへの段階的移行方針を策定・推進中。
+  - バイトルトーク（シフト管理・メッセージング）とのSSOログイン実現に向け、Auth0→Cognito間のユーザー情報移行方針を設計。クロスセル・アップセルのためのサービス横断認証アーキテクチャの設計をバイトルトーク開発チームと推進中。
+- **3万MAUのGo Next.jsによるスポットバイトルの開発（2025年9月〜2026年1月）**
   - 求人広告AI自動審査機能を短期開発(1週間、1200行)でリリースし、日次100件の審査業務を自動化。AWS Bedrock(Claude)統合において、トークン超過・JSON出力エラーなど実運用課題に対処（出力検証、パラメーター修正など）。プロンプトをテキストベース管理し非エンジニアでも調整可能にすることで、運用開始後の継続改善を実現。
-  - 日次10万リクエスト規模のGo製APIに対し、Dockerベースの自動テスト基盤を整備。シフトレフトテストの方針をチームに提案・導入し、GitHub ActionsによるCIパイプラインで品質保証を自動化。日次エラー件数を平均7.5件から0.3件に削減（96%減）。
+  - 日次20万リクエスト規模のGo製APIに対し、Dockerベースの自動テスト基盤を整備。シフトレフトテストの方針をチームに提案・導入し、GitHub ActionsによるCIパイプラインで品質保証を自動化。日次エラー件数を平均7.5件から0.3件に削減（96%減）。
   - ローカル開発環境の整備およびAIツール（Claude Code/Gemini）の導入・仕組み化を主導し、7名の開発チームのPR作成数を1日1件から2件に向上
-- 3万MAUのバイトル企業向けアカウントの認証基盤マイクロサービス化（Go/AWS Cognito/Oracle、2025年3月〜2025年9月）
+- **3万MAUのバイトル企業向けアカウントの認証基盤マイクロサービス化（Go/AWS Cognito/Oracle、2025年3月〜2025年9月）**
   - PHPモノリスからAWS Cognitoへの認証基盤切り出しにおいてテックリードを担当。Auth0とCognitoを比較しコスト面からCognitoを選定。本番トラフィック（ピーク約10req/s）をNew Relicで計測し、Cognitoサービスクォータとの適合性を検証した上で設計。
-  - Oracle基幹DBとCognitoユーザープール間のユーザーライフサイクル操作（同期・削除）を担うGo製APIを設計・実装。整合性担保にはOutboxパターン等を検討したが、書き込み頻度の低さと移行期間中はモノリス側DBが正とする運用方針から、Slackアラートによる運用カバーを選択。
+  - Oracle基幹DBとCognitoユーザープール間のユーザーライフサイクル操作（同期・削除）を担うGo製APIを設計・実装。
   - DB・Cognito接続込みの結合テストスイート（150ケース、日次7〜8回実行）を構築。2つのデータソースを跨ぐAPIの性質上、結合テストなしでは検証が成立しないと判断し導入。手動検証では1ケースあたりUI操作で30〜60秒要していた工程を自動化。
   - ECS移行との依存により開発期間が8ヶ月から4ヶ月に短縮される中、パートナー5名を短期導入しリード。AI生成コードのレビューサイクルを確立し、スキルレベルに応じてAI詳細設計書の提供と直接実装を使い分けるオンボーディング体制を構築。15,000行規模のプロダクトをリリース。
 
 #### ソフトウェアエンジニア（2022年1月〜2025年2月）
 
-- 求人広告出稿主向け管理画面のフロントエンド開発（Vue3→React、2023年1月〜2025年2月）
+- **求人広告出稿主向け管理画面のフロントエンド開発（Vue3→React、2023年1月〜2025年2月）**
   - デザインシステムのコンポーネント設計方針（Atomic Design）を策定・文書化。Molecules/Organismsの分類基準をドメインロジックの有無に絞ることで、チームメンバーの設計判断のばらつきを解消。約150コンポーネントを整備。
   - Chromatic（VRT SaaS）の導入をセキュリティ審査・利用規約確認を含めて主導。SP表示やエラー状態など目検で漏れやすいパターンの回帰テストを自動化し、全コンポーネントを1画面に載せていた運用を廃止。コンフリクト頻発（PR 3回に1回、解消に都度20〜30分）を解消。
   - Vue3からReactへの移行を技術評価から主導。Vue/React/Svelteで同一画面を試作比較し、バックエンドエンジニアが多いチーム構成との親和性（JSX＝関数的な記述）を根拠にReactを提案・採用。
-- 求人広告出稿主向け管理画面の新規開発（NestJS/Nuxt.js、2022年1月〜2022年12月）
+- **求人広告出稿主向け管理画面の新規開発（NestJS/Nuxt.js、2022年1月〜2022年12月）**
   - テストゼロ・Controller直書きの15,000行コードベースに対し、レイヤードアーキテクチャ（Controller/Service/Repository）へのリファクタリングを主導。NestJSバックエンドのユニットテストを導入しカバレッジを0%から50%に改善。ESLintルール整備とチーム合意形成によりコード品質の基準を確立。
 
 ### 株式会社AIDIOT（2021年3月〜2021年12月）
@@ -42,34 +44,26 @@
 ### ソフトブレーン株式会社（2020年4月〜2021年3月）
 
 - **バックエンド開発**（Java）
-  - 既存システムのバグ修正・テスト実施
 
 ## OSS コントリビュート
 
-- Hono（Web Framework）: 15 contributions
-  - Lambda@Edge向けconnInfo対応
+- **Hono（Web Framework）: 15 contributions**
   - タイミング攻撃対策コードの改善
   - HTTPヘッダーパースのベンチマーク検証
-- AWS CDK: 7 contributions
+- **AWS CDK: 7 contributions**
   - Cognito属性マッピングへの`emailVerified`サポート追加。Apple・GoogleなどIdPごとの公式仕様を調査し、PRマージ可能なエビデンスを提示
-- Vue Test Utils: 2 contributions
-- その他: Effect-TS, eslint-plugin-vitest, yamada-ui, Laravel-Excel,
-  react-datepicker, devbox, auth0-PHP, php/doc-ja
+- **Vue Test Utils: 2 contributions**
+- **その他: Effect-TS, yamada-ui, Laravel-Excel, react-datepicker, auth0-PHP**
 
 ## 個人プロジェクト・学習
 
-- [Amazon Cognito SRP認証ヘルパー](https://github.com/yasuaki640/cognito-srp-php)
-  - Cognitoが要求するSRP（Secure Remote Password）プロトコルのクライアント側計算
-    （大素数DH鍵交換、HMAC-SHA256チャレンジレスポンス署名）をPHPで実装。
-    公式SDKにPHP用SRPヘルパーが存在しないため自作し、composerパッケージとして公開。
-- [Kotlin/NativeによるHTTP APIサーバー（Ktor、シングルバイナリ）](https://github.com/yasuaki640/impressive-ktor-native-api)
-  - 業務のサーバーサイドの移行先について、Kotlinへの移行も考えられていたため、趣味プロジェクトも兼ねて実装。
-- [TypeScriptによる簡易DB実装](https://github.com/yasuaki640/tsqlite)
-- [PHPによるWebブラウザのレンダリングエンジン実装](https://github.com/yasuaki640/php-rendering-engine)
-  - example.comなど単純な静的ページの解析と描画
+- **[Amazon Cognito SRP認証ヘルパー](https://github.com/yasuaki640/cognito-srp-php)**
+  - Cognitoが要求するSRP（Secure Remote Password）プロトコルのクライアント側計算大素数DH鍵交換、HMAC-SHA256チャレンジレスポンス署名）をPHPで実装。
+- **[TypeScriptによる簡易DB実装](https://github.com/yasuaki640/tsqlite)**
+- **[PHPによるWebブラウザのレンダリングエンジン実装](https://github.com/yasuaki640/php-rendering-engine)**
 
 ## 登壇・技術発信
 
-- PHP Conference 2025 登壇：「ウェブブラウザのレンダリングエンジンを実装してみよう」
-- PHPerKaigi 2024 登壇：「PHPにCライブラリをつなぎこんで使って簡単なメロディを演奏する」
-- PHP Conference 2023 LT登壇：「PHPのOpcodeを読んでみよう」
+- **PHP Conference 2025 登壇：「ウェブブラウザのレンダリングエンジンを実装してみよう」**
+- **PHPerKaigi 2024 登壇：「PHPにCライブラリをつなぎこんで使って簡単なメロディを演奏する」**
+- **PHP Conference 2023 LT登壇：「PHPのOpcodeを読んでみよう」**

--- a/index.html
+++ b/index.html
@@ -64,10 +64,10 @@
       <section id="resume">
         <h2>職務経歴書</h2>
         <a
-          href="https://github.com/yasuaki640/yasuaki640.github.io/blob/master/docs/resume.md"
+          href="./docs/%E8%81%B7%E5%8B%99%E7%B5%8C%E6%AD%B4%E6%9B%B8_%E6%B8%A1%E9%82%89%E6%B3%B0%E6%9B%89.md"
           target="_blank"
           rel="noopener noreferrer"
-          >resume.md (GitHub)</a
+          >職務経歴書（Markdown）</a
         >
       </section>
 


### PR DESCRIPTION
## Summary
- 日本語版の職務経歴書（`職務経歴書_渡邉泰曉.md`）を追加
- index.html のリンク先を英語版 resume.md から日本語版に変更

## Test plan
- [ ] GitHub Pages にデプロイ後、職務経歴書リンクが日本語版を正しく開くことを確認
- [ ] 職務経歴書の内容が正しく表示されることを確認